### PR TITLE
Fix EAN assignment logic

### DIFF
--- a/4ph_ue_item_ addapted V2.js
+++ b/4ph_ue_item_ addapted V2.js
@@ -62,7 +62,9 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
 
         const recordId = recItem.id;
         updateSKUNumberRecords(recordId, skuNumbers);
-        assignItemToEANNumber(recordId, eanNumber);
+        if (eanNumber) {
+          assignItemToEANNumber(recordId, eanNumber);
+        }
 
         const newRecItemSetInactive = record.load({
           type: scriptContext.newRecord.type,
@@ -141,9 +143,10 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
 
   function assignItemToEANNumber(itemId, eanNumber) {
     try {
+      if (!eanNumber) return;
       const result = search.create({
         type: "customrecord_4ph_ean_numbers",
-        filters: [["name", "haskeywords", eanNumber]],
+        filters: [["name", "is", eanNumber]],
         columns: ["internalid"],
       })
         .run()
@@ -213,5 +216,8 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
     return results.length > 0 ? results[0].id : null;
   };
 
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { beforeLoad, afterSubmit, assignItemToEANNumber };
+  }
   return { beforeLoad, afterSubmit };
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "codex-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/assignItemToEANNumber.test.js"
+  }
+}

--- a/test/assignItemToEANNumber.test.js
+++ b/test/assignItemToEANNumber.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadModule(stubs) {
+  const module = { exports: {} };
+  global.define = (deps, factory) => {
+    module.exports = {};
+    factory(stubs.record, stubs.search, stubs.query);
+  };
+  global.module = module;
+  vm.runInThisContext(fs.readFileSync('./4ph_ue_item_ addapted V2.js', 'utf8'), {
+    filename: 'script.js',
+  });
+  delete global.module;
+  return module.exports;
+}
+
+const searchCalls = { create: 0 };
+const stubs = {
+  record: { submitFields: () => {} },
+  search: {
+    create: () => {
+      searchCalls.create++;
+      return { run: () => ({ getRange: () => [] }) };
+    },
+  },
+  query: {},
+};
+
+const mod = loadModule(stubs);
+mod.assignItemToEANNumber(123, null);
+assert.strictEqual(searchCalls.create, 0, 'search.create should not be called when eanNumber is falsy');
+console.log('assignItemToEANNumber tests passed');


### PR DESCRIPTION
## Summary
- safeguard EAN assignment and only run when EAN present
- ensure `assignItemToEANNumber` validates input and performs exact search
- export functions for node-based tests
- add a simple unit test for the early-return logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684181f536e4833398d23bf7ce558059