### PR TITLE
Handle stale EAN reservations

### DIFF
--- a/4ph_ue_item_ addapted V2.js
+++ b/4ph_ue_item_ addapted V2.js
@@ -115,7 +115,7 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
       filters: [
         ["name", "isnotempty", ""],
         "AND",
-        ["custrecord_4ph_item", "anyof", "@NONE@"],
+        ["custrecord_4ph_item", "anyof", ["@NONE@", "-1"]],
       ],
       columns: [search.createColumn({ name: "name", sort: search.Sort.ASC })],
     });
@@ -224,7 +224,7 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
   };
 
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { beforeLoad, afterSubmit, assignItemToEANNumber };
+    module.exports = { beforeLoad, afterSubmit, assignItemToEANNumber, getAndReserveUniqueEAN };
   }
   return { beforeLoad, afterSubmit };
 });

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "codex-test",
   "version": "1.0.0",
   "scripts": {
-    "test": "node test/assignItemToEANNumber.test.js"
+    "test": "node test/assignItemToEANNumber.test.js && node test/getAndReserveUniqueEAN.test.js"
   }
 }

--- a/test/getAndReserveUniqueEAN.test.js
+++ b/test/getAndReserveUniqueEAN.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadModule(stubs) {
+  const module = { exports: {} };
+  global.define = (deps, factory) => {
+    module.exports = {};
+    factory(stubs.record, stubs.search, stubs.query);
+  };
+  global.module = module;
+  vm.runInThisContext(fs.readFileSync('./4ph_ue_item_ addapted V2.js', 'utf8'), {
+    filename: 'script.js',
+  });
+  delete global.module;
+  return module.exports;
+}
+
+const capturedFilters = [];
+const stubs = {
+  record: { submitFields: () => {} },
+  search: {
+    Sort: { ASC: 'ASC' },
+    createColumn: () => ({}),
+    create: (opts) => {
+      capturedFilters.push(opts.filters);
+      return {
+        run: () => ({
+          getRange: () => [{ id: '1', getValue: () => 'EAN1' }]
+        })
+      };
+    }
+  },
+  query: {}
+};
+
+const mod = loadModule(stubs);
+const first = mod.getAndReserveUniqueEAN();
+const second = mod.getAndReserveUniqueEAN();
+
+assert.deepStrictEqual(first, { id: '1', eanNumber: 'EAN1' });
+assert.deepStrictEqual(second, { id: '1', eanNumber: 'EAN1' });
+assert.ok(JSON.stringify(capturedFilters[0]).includes('-1'), 'search filter should include -1');
+console.log('getAndReserveUniqueEAN tests passed');


### PR DESCRIPTION
## Summary
- support reusing '-1' EAN reservations in `getAndReserveUniqueEAN`
- export `getAndReserveUniqueEAN` for testing
- add unit tests for new behaviour
- run multiple tests via npm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841885ddd4883339b8d13d4bcb28c65