### PR TITLE
Handle beforeLoad errors and add tests

### DIFF
--- a/4ph_ue_item_ addapted V2.js
+++ b/4ph_ue_item_ addapted V2.js
@@ -11,7 +11,9 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
       if ([userEventType.CREATE].includes(scriptContext.type)) {
         setDefaultValues(recItem);
       }
-    } catch (e) {}
+    } catch (e) {
+      log.error("Error::beforeLoad", e);
+    }
   };
 
   const afterSubmit = (scriptContext) => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "codex-test",
   "version": "1.0.0",
   "scripts": {
-    "test": "node test/assignItemToEANNumber.test.js"
+    "test": "node test/assignItemToEANNumber.test.js && node test/beforeLoadLogging.test.js"
   }
 }

--- a/test/beforeLoadLogging.test.js
+++ b/test/beforeLoadLogging.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadModule(stubs) {
+  const module = { exports: {} };
+  global.define = (deps, factory) => {
+    module.exports = {};
+    factory(stubs.record, stubs.search, stubs.query);
+  };
+  global.module = module;
+  global.log = stubs.log;
+  vm.runInThisContext(fs.readFileSync('./4ph_ue_item_ addapted V2.js', 'utf8'), {
+    filename: 'script.js',
+  });
+  delete global.module;
+  return module.exports;
+}
+
+const logCalls = [];
+const stubs = {
+  record: {},
+  search: {},
+  query: {},
+  log: {
+    error: (title, err) => logCalls.push({ title, err }),
+  },
+};
+
+const mod = loadModule(stubs);
+global.log = stubs.log;
+
+const scriptContext = {
+  UserEventType: { CREATE: 'create' },
+  type: 'create',
+  newRecord: {
+    setValue: () => {
+      throw new Error('fail');
+    },
+  },
+};
+
+mod.beforeLoad(scriptContext);
+delete global.log;
+assert.strictEqual(logCalls.length, 1, 'Error should be logged when beforeLoad throws');
+console.log('beforeLoad logging test passed');


### PR DESCRIPTION
## Summary
- log errors in `beforeLoad` for easier debugging
- add unit test ensuring errors in `beforeLoad` are logged
- update test script to run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684188629ad8833399353db5fe45f0df