### PR TITLE
Add EAN reservation tests

### DIFF
--- a/4ph_ue_item_ addapted V2.js
+++ b/4ph_ue_item_ addapted V2.js
@@ -224,7 +224,13 @@ define(["N/record", "N/search", "N/query"], (record, search, query) => {
   };
 
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { beforeLoad, afterSubmit, assignItemToEANNumber };
+    module.exports = {
+      beforeLoad,
+      afterSubmit,
+      assignItemToEANNumber,
+      setEANNumber,
+      getAndReserveUniqueEAN,
+    };
   }
   return { beforeLoad, afterSubmit };
 });

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "codex-test",
   "version": "1.0.0",
   "scripts": {
-    "test": "node test/assignItemToEANNumber.test.js"
+    "test": "node test/assignItemToEANNumber.test.js && node test/getAndReserveUniqueEAN.test.js && node test/setEANNumber.test.js"
   }
 }

--- a/test/getAndReserveUniqueEAN.test.js
+++ b/test/getAndReserveUniqueEAN.test.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadModule(stubs) {
+  const module = { exports: {} };
+  global.define = (deps, factory) => {
+    module.exports = {};
+    factory(stubs.record, stubs.search, stubs.query);
+  };
+  global.module = module;
+  global.log = { error: () => {}, audit: () => {} };
+  vm.runInThisContext(fs.readFileSync('./4ph_ue_item_ addapted V2.js', 'utf8'), {
+    filename: 'script.js',
+  });
+  delete global.module;
+  delete global.define;
+  return module.exports;
+}
+
+// Case: available EAN
+(() => {
+  const submitCalls = [];
+  const stubs = {
+    record: { submitFields: (opts) => { submitCalls.push(opts.id); } },
+    search: {
+      Sort: { ASC: 'ASC' },
+      createColumn: (o) => o,
+      create: () => ({
+        run: () => ({
+          getRange: () => [ { id: '1', getValue: () => 'EAN1' } ]
+        })
+      })
+    },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const result = mod.getAndReserveUniqueEAN();
+  assert.deepStrictEqual(result, { id: '1', eanNumber: 'EAN1' });
+  assert.strictEqual(submitCalls.length, 1);
+})();
+
+// Case: first reserved fails then next succeeds
+(() => {
+  const submitCalls = [];
+  const stubs = {
+    record: { submitFields: (opts) => {
+      submitCalls.push(opts.id);
+      if (opts.id === '1') throw new Error('fail');
+    } },
+    search: {
+      Sort: { ASC: 'ASC' },
+      createColumn: (o) => o,
+      create: () => ({
+        run: () => ({
+          getRange: () => [
+            { id: '1', getValue: () => 'EAN1' },
+            { id: '2', getValue: () => 'EAN2' }
+          ]
+        })
+      })
+    },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const result = mod.getAndReserveUniqueEAN();
+  assert.deepStrictEqual(result, { id: '2', eanNumber: 'EAN2' });
+  assert.deepStrictEqual(submitCalls, ['1','2']);
+})();
+
+// Case: no available EAN
+(() => {
+  const stubs = {
+    record: { submitFields: () => { throw new Error('should not be called'); } },
+    search: {
+      Sort: { ASC: 'ASC' },
+      createColumn: (o) => o,
+      create: () => ({ run: () => ({ getRange: () => [] }) })
+    },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const result = mod.getAndReserveUniqueEAN();
+  assert.strictEqual(result, null);
+})();
+
+console.log('getAndReserveUniqueEAN tests passed');

--- a/test/setEANNumber.test.js
+++ b/test/setEANNumber.test.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadModule(stubs) {
+  const module = { exports: {} };
+  global.define = (deps, factory) => {
+    module.exports = {};
+    factory(stubs.record, stubs.search, stubs.query);
+  };
+  global.module = module;
+  global.log = { error: () => {}, audit: () => {} };
+  vm.runInThisContext(fs.readFileSync('./4ph_ue_item_ addapted V2.js', 'utf8'), {
+    filename: 'script.js',
+  });
+  delete global.module;
+  delete global.define;
+  return module.exports;
+}
+
+function makeRec(pop, upc) {
+  return {
+    type: 'inventoryitem',
+    id: '100',
+    getValue: ({fieldId}) => {
+      if (fieldId === 'custitem_4ph_pop_ean_autom') return pop;
+      if (fieldId === 'upccode') return upc;
+    }
+  };
+}
+
+// EAN available
+(() => {
+  const submitted = [];
+  let calls = 0;
+  const stubs = {
+    record: {
+      submitFields: (opts) => {
+        calls++;
+        if (opts.values.upccode) submitted.push(opts.values.upccode);
+      },
+    },
+    search: {
+      Sort: { ASC: 'ASC' },
+      createColumn: (o) => o,
+      create: () => ({ run: () => ({ getRange: () => [ { id:'1', getValue: ()=>'111'} ] }) })
+    },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const ean = mod.setEANNumber(makeRec(true, ''));
+  assert.strictEqual(ean, '111');
+  assert.deepStrictEqual(submitted, ['111']);
+  assert.strictEqual(calls, 2);
+})();
+
+// No EAN available
+(() => {
+  const stubs = {
+    record: { submitFields: () => { throw new Error('should not update'); } },
+    search: {
+      Sort: { ASC: 'ASC' },
+      createColumn: (o) => o,
+      create: () => ({ run: () => ({ getRange: () => [] }) })
+    },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const ean = mod.setEANNumber(makeRec(true, ''));
+  assert.strictEqual(ean, undefined);
+})();
+
+// Item already has EAN
+(() => {
+  const stubs = {
+    record: { submitFields: () => { throw new Error('should not update'); } },
+    search: { Sort:{ASC:'ASC'}, createColumn:(o)=>o, create: () => ({ run: () => ({ getRange: () => [] }) }) },
+    query: {}
+  };
+  const mod = loadModule(stubs);
+  const ean = mod.setEANNumber(makeRec(true, 'existing'));
+  assert.strictEqual(ean, undefined);
+})();
+
+console.log('setEANNumber tests passed');


### PR DESCRIPTION
## Summary
- export `setEANNumber` and `getAndReserveUniqueEAN` for testing
- add unit tests for reserving EANs
- test `setEANNumber` behaviour with available and unavailable EANs
- update test script to run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841886eebd48333b408a3ea02355a42