### PR TITLE
Improve EAN reservation search

### DIFF
--- a/test/getAndReserveUniqueEAN.test.js
+++ b/test/getAndReserveUniqueEAN.test.js
@@ -25,8 +25,11 @@ const stubs = {
     create: (opts) => {
       capturedFilters.push(opts.filters);
       return {
-        run: () => ({
-          getRange: () => [{ id: '1', getValue: () => 'EAN1' }]
+        runPaged: () => ({
+          pageRanges: [{ index: 0 }],
+          fetch: () => ({
+            data: [{ id: '1', getValue: () => 'EAN1' }]
+          })
         })
       };
     }


### PR DESCRIPTION
## Summary
- allow getAndReserveUniqueEAN to iterate through paged search results
- adjust getAndReserveUniqueEAN unit test for paged search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841946e955c833396698f7baefefb9c