### PR TITLE
Simplify EAN lookup

### DIFF
--- a/test/getAndReserveUniqueEAN.test.js
+++ b/test/getAndReserveUniqueEAN.test.js
@@ -21,15 +21,14 @@ const stubs = {
   record: { submitFields: () => {} },
   search: {
     Sort: { ASC: 'ASC' },
-    createColumn: () => ({}),
+    Operator: { ISNOTEMPTY: 'isnotempty', ANYOF: 'anyof' },
+    createColumn: (opts) => opts,
+    createFilter: (opts) => opts,
     create: (opts) => {
       capturedFilters.push(opts.filters);
       return {
-        runPaged: () => ({
-          pageRanges: [{ index: 0 }],
-          fetch: () => ({
-            data: [{ id: '1', getValue: () => 'EAN1' }]
-          })
+        run: () => ({
+          getRange: () => [{ id: '1', getValue: () => 'EAN1' }]
         })
       };
     }
@@ -43,5 +42,9 @@ const second = mod.getAndReserveUniqueEAN();
 
 assert.deepStrictEqual(first, { id: '1', eanNumber: 'EAN1' });
 assert.deepStrictEqual(second, { id: '1', eanNumber: 'EAN1' });
-assert.ok(JSON.stringify(capturedFilters[0]).includes('-1'), 'search filter should include -1');
+const expectedFilters = [
+  { name: 'name', operator: 'isnotempty' },
+  { name: 'custrecord_4ph_item', operator: 'anyof', values: ['@NONE@'] }
+];
+assert.deepStrictEqual(capturedFilters[0], expectedFilters, 'search filters should match');
 console.log('getAndReserveUniqueEAN tests passed');


### PR DESCRIPTION
## Summary
- fetch available EAN with simple search helper
- adjust getAndReserveUniqueEAN to use new helper
- update unit test stubs and expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68419a307dbc833389994fe91ae1b07f